### PR TITLE
Corrected pairs to reflect yt video lecture code

### DIFF
--- a/walk3/walk3.go
+++ b/walk3/walk3.go
@@ -94,7 +94,7 @@ func searchTree(dir string, pairs chan<- pair, wg *sync.WaitGroup, limits chan b
 func run(dir string) results {
 	workers := 2 * runtime.GOMAXPROCS(0)
 	limits := make(chan bool, workers)
-	pairs := make(chan pair)
+	pairs := make(chan pair, workers)
 	result := make(chan results)
 	wg := new(sync.WaitGroup)
 


### PR DESCRIPTION
In the yt video playground where this code was created, the `pairs` channel was buffered to the workers and this code file omits that presentation element. Was this intentionally done or should this PR be merged?